### PR TITLE
fix: add missing dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.10.7",
+    "commitizen": "^4.0.3",
     "cross-env": "^7.0.0",
     "cz-conventional-changelog": "3.0.2",
     "husky": "^3.1.0",


### PR DESCRIPTION
I somehow forgot to add the dependency to the package.json. It is in the yarn.lock file which is curious. Most curious.

Sorry.